### PR TITLE
chore: reduce pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
   unrs-resolver: false
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 1440


### PR DESCRIPTION
Sets pnpm minimumReleaseAge to 1440 minutes (one day).